### PR TITLE
Reduce variable conflict risk

### DIFF
--- a/bash-menu.sh
+++ b/bash-menu.sh
@@ -36,16 +36,16 @@ fi
 
 # Get script root (as we are sourced from another script, $0 will not be us)
 declare -r menuScript=$(readlink -f ${BASH_SOURCE[0]})
-root=$(dirname "$menuScript")
+menuRoot=$(dirname "$menuScript")
 
 # Ensure we can access our dependencies
-if [ ! -s "$root/bash-draw.sh" ]; then
+if [ ! -s "$menuRoot/bash-draw.sh" ]; then
     echo "ERROR: Missing required draw.sh script"
     exit 1
 fi
 
 # Load terminal drawing functions
-. "$root/bash-draw.sh"
+. "$menuRoot/bash-draw.sh"
 
 
 ################################


### PR DESCRIPTION
The `bash-menu.sh` script sets the global variable `root` to the directory holding bash-menu. This is a generic enough name to possibly be used by other scripts, so to reduce the risk of this conflicting with a user variable, it should be renamed.